### PR TITLE
AIR University test duration and merit calculation fixed

### DIFF
--- a/src/components/university/UniversityGrid.tsx
+++ b/src/components/university/UniversityGrid.tsx
@@ -88,6 +88,23 @@ const UniversityGrid: React.FC<UniversityGridProps> = ({ universities = defaultU
                 textShadow: '0 2px 6px rgba(0, 0, 0, 0.5)',
                 transition: 'transform 0.3s ease, opacity 0.3s ease'
               }}>{university.name}</p>
+              {/* Display merit formula for each program if available */}
+              {university.programs && university.programs.length > 0 && (
+                <div style={{ marginBottom: '16px' }}>
+                  {university.programs.map((program) => (
+                    program.formula ? (
+                      <div key={program.id} style={{ color: '#b6eaff', fontSize: '0.95rem', marginBottom: 4 }}>
+                        <span style={{ fontWeight: 600 }}>{program.name}:</span> 
+                        <span>
+                          {program.formula.matriculation !== undefined && `SSC: ${(program.formula.matriculation * 100).toFixed(0)}%`}
+                          {program.formula.intermediate !== undefined && `, HSSC: ${(program.formula.intermediate * 100).toFixed(0)}%`}
+                          {program.formula.entryTest !== undefined && `, Entry Test: ${(program.formula.entryTest * 100).toFixed(0)}%`}
+                        </span>
+                      </div>
+                    ) : null
+                  ))}
+                </div>
+              )}
               
               {university.isImplemented ? (
                 <Link 

--- a/src/data/testPatterns.ts
+++ b/src/data/testPatterns.ts
@@ -240,7 +240,7 @@ const testPatterns: UniversityTestPattern[] = [
     name: "Air University Entry Test",
     pattern: {
       totalMCQs: 100,
-      duration: "3 hours",
+      duration: "2 hours",
       totalMarks: 100,
       isComputerBased: true,
       hasNegativeMarking: false,

--- a/src/data/universities.ts
+++ b/src/data/universities.ts
@@ -1315,9 +1315,9 @@ const universities: University[] = [
         name: "Engineering Programs",
         testOptions: ["CBT", "NTS"],
         formula: {
-          matriculation: 0.00,
+          matriculation: 0.10,
           intermediate: 0.50,
-          entryTest: 0.50
+          entryTest: 0.40
         },
         minimumCriteria: {
           matriculation: 60,


### PR DESCRIPTION
https://www.au.edu.pk/Pages/Admission/prepare_adm_test.aspx
AIR University website lists the merit calculation for Engineering programs as that 10% of SSC and 40% of Entry Test Score will be counted.
Also the test time is 2 hours not 3 hours as per the website.

Furthermore, I have verified my calculations and changes within the website of UniCalc.

Thanks

<img width="608" height="648" alt="image" src="https://github.com/user-attachments/assets/5fc582e3-047d-4dae-b364-6fc00b33988b" />
<img width="689" height="607" alt="image" src="https://github.com/user-attachments/assets/51c741db-fdc2-455f-8404-97266359e98d" />
<img width="893" height="340" alt="image" src="https://github.com/user-attachments/assets/9238d7a6-dcb2-4c7c-83e3-9c4ee90ab682" />
